### PR TITLE
[#35] 이미지 aws s3에 저장  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+aws.properties
+

--- a/docs/jenkins/jenkins_pr_build.sh
+++ b/docs/jenkins/jenkins_pr_build.sh
@@ -2,7 +2,6 @@
 
 echo $payload > payload.txt
 
-
 action=`python -c 'import json, os; d = json.loads(open("payload.txt").read()); print d["action"]'`
 
 if [ $action != "opened" || $action != "reopened" || $action != "edited" || $action != "review_requested"]; then exit ; fi
@@ -18,16 +17,16 @@ result=`./mvnw clean test | grep -q "BUILD SUCCESS"; echo $?`
 
 echo $result
 
-if [ "$result" == "1" ]; then \
-	curl "${curl_url}" \
+if [ "$result" == "0" ]; then \
+  curl "${curl_url}" \
   		-H "Content-Type: application/json" \
   		-H "Authorization: token <TOKEN>" \
   		-X POST \
-  		-d "{\"state\": \"failure\",\"context\": \"continuous-integration/jenkins\", \"description\": \"Jenkins\", \"target_url\": \"http://20.194.0.141/job/dangdang_ci/$BUILD_NUMBER/console\"}"; \
+  		-d "{\"state\": \"success\",\"context\": \"continuous-integration/jenkins\", \"description\": \"Jenkins\", \"target_url\": \"http://20.194.0.141/job/dangdang_ci/$BUILD_NUMBER/console\"}"; \
 else \
 	curl "${curl_url}" \
   		-H "Content-Type: application/json" \
   		-H "Authorization: token <TOKEN>" \
   		-X POST \
-  		-d "{\"state\": \"success\",\"context\": \"continuous-integration/jenkins\", \"description\": \"Jenkins\", \"target_url\": \"http://20.194.0.141/job/dangdang_ci/$BUILD_NUMBER/console\"}"; \
+  		-d "{\"state\": \"failure\",\"context\": \"continuous-integration/jenkins\", \"description\": \"Jenkins\", \"target_url\": \"http://20.194.0.141/job/dangdang_ci/$BUILD_NUMBER/console\"}"; \
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <java.version>1.8</java.version>
         <swagger.version>2.9.2</swagger.version>
+        <aws.version>2.2.1.RELEASE</aws.version>
     </properties>
 
     <dependencies>
@@ -53,7 +54,16 @@
             <artifactId>springfox-swagger-ui</artifactId>
             <version>${swagger.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-aws</artifactId>
+            <version>${aws.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-aws-autoconfigure</artifactId>
+            <version>${aws.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <java.version>1.8</java.version>
         <swagger.version>2.9.2</swagger.version>
-        <aws.version>2.2.1.RELEASE</aws.version>
     </properties>
 
     <dependencies>
@@ -37,13 +36,11 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <scope>runtime</scope>
         </dependency>
-
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
@@ -57,12 +54,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-aws</artifactId>
-            <version>${aws.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-aws-autoconfigure</artifactId>
-            <version>${aws.version}</version>
+            <version>2.2.1.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -28,3 +28,25 @@ CREATE TABLE Pet
 	constraint pet_pk
 		primary key (id)
 );
+
+CREATE TABLE Image
+(
+    id bigint auto_increment primary key,
+    filePath varchar(100) not null,
+    fileName varchar(100) not null,
+    priority int not null
+);
+
+CREATE TABLE PetProfile
+(
+    id bigint auto_increment primary key,
+    imageId bigint not null,
+    petId bigint not null
+);
+
+CREATE TABLE UserProfile
+(
+    id bigint auto_increment primary key,
+    imageId bigint not null,
+    userId bigint not null
+);

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -33,15 +33,15 @@ CREATE TABLE Image
 (
     id bigint auto_increment primary key,
     filePath varchar(100) not null,
-    fileName varchar(100) not null,
-    priority int not null
+    fileName varchar(100) not null
 );
 
 CREATE TABLE PetProfile
 (
     id bigint auto_increment primary key,
     imageId bigint not null,
-    petId bigint not null
+    petId bigint not null,
+    priority int not null
 );
 
 CREATE TABLE UserProfile

--- a/src/main/java/com/depromeet/dodo/auth/common/SignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/SignUpRequest.java
@@ -1,6 +1,11 @@
 package com.depromeet.dodo.auth.common;
 
+import java.util.Map;
+
+import org.springframework.web.multipart.MultipartFile;
+
 import com.depromeet.dodo.common.dto.Gender;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,6 +18,7 @@ public class SignUpRequest {
 	private String address;
 	private String introduce;
 	private PetInfo petInfo;
+	private MultipartFile profileImage;
 
 	@AllArgsConstructor
 	@Getter
@@ -23,5 +29,7 @@ public class SignUpRequest {
 		private String breed;
 		private boolean fixing;
 		private boolean vaccination;
+		private Map<Integer, MultipartFile> profileImage;
 	}
+
 }

--- a/src/main/java/com/depromeet/dodo/auth/common/SignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/SignUpRequest.java
@@ -1,10 +1,11 @@
 package com.depromeet.dodo.auth.common;
 
-import java.util.Map;
+import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
 import com.depromeet.dodo.common.dto.Gender;
+import com.depromeet.dodo.common.dto.ProfileImage;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,8 +21,8 @@ public class SignUpRequest {
 	private PetInfo petInfo;
 	private MultipartFile profileImage;
 
-	@AllArgsConstructor
 	@Getter
+	@AllArgsConstructor
 	public static class PetInfo {
 		private String name;
 		private Gender gender;
@@ -29,7 +30,7 @@ public class SignUpRequest {
 		private String breed;
 		private boolean fixing;
 		private boolean vaccination;
-		private Map<Integer, MultipartFile> profileImage;
+		private List<ProfileImage> profileImages;
 	}
 
 }

--- a/src/main/java/com/depromeet/dodo/auth/common/UserInfo.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/UserInfo.java
@@ -1,6 +1,7 @@
 package com.depromeet.dodo.auth.common;
 
 import com.depromeet.dodo.common.dto.Gender;
+
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/depromeet/dodo/auth/common/dto/SignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/dto/SignUpRequest.java
@@ -1,4 +1,4 @@
-package com.depromeet.dodo.auth.common;
+package com.depromeet.dodo.auth.common.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/depromeet/dodo/auth/common/dto/UserInfo.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/dto/UserInfo.java
@@ -1,4 +1,4 @@
-package com.depromeet.dodo.auth.common;
+package com.depromeet.dodo.auth.common.dto;
 
 import com.depromeet.dodo.common.dto.Gender;
 

--- a/src/main/java/com/depromeet/dodo/auth/common/service/ProfileUploadService.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/service/ProfileUploadService.java
@@ -1,0 +1,44 @@
+package com.depromeet.dodo.auth.common.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.depromeet.dodo.common.dto.ImageWithPriority;
+import com.depromeet.dodo.common.dto.ProfileImage;
+import com.depromeet.dodo.common.service.FileUploadService;
+import com.depromeet.dodo.image.domain.Image;
+import com.depromeet.dodo.image.domain.PetProfile;
+import com.depromeet.dodo.image.service.PetProfileService;
+import com.depromeet.dodo.image.service.UserProfileService;
+import com.depromeet.dodo.pet.domain.Pet;
+import com.depromeet.dodo.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileUploadService {
+
+	private final FileUploadService fileUploadService;
+	private final PetProfileService petProfileService;
+	private final UserProfileService userProfileService;
+
+	public void addPetProfile(Pet pet, List<ProfileImage> profileImages) {
+		List<PetProfile> petProfiles = new ArrayList<>();
+		List<ImageWithPriority> profileWithPriority = fileUploadService.multiFileUpload(profileImages);
+
+		profileWithPriority.stream()
+			.forEach(x -> petProfiles.add(new PetProfile(x.getImage(), pet, x.getPriority())));
+
+		petProfileService.addProfiles(petProfiles);
+	}
+
+	public void addUserProfile(User user, MultipartFile profileImage) {
+		Image userProfile = fileUploadService.singleFileUpload(profileImage);
+		userProfileService.addImage(user, userProfile);
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/auth/controller/AuthorizeController.java
+++ b/src/main/java/com/depromeet/dodo/auth/controller/AuthorizeController.java
@@ -10,17 +10,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.depromeet.dodo.auth.common.UserInfo;
+import com.depromeet.dodo.auth.common.dto.UserInfo;
 import com.depromeet.dodo.auth.thirdparty.kakao.request.KakaoSignInRequest;
 import com.depromeet.dodo.auth.thirdparty.kakao.request.KakaoSignUpRequest;
 import com.depromeet.dodo.auth.thirdparty.kakao.service.KakaoAuthService;
 import com.depromeet.dodo.auth.thirdparty.naver.request.NaverSignInRequest;
 import com.depromeet.dodo.auth.thirdparty.naver.request.NaverSignUpRequest;
 import com.depromeet.dodo.auth.thirdparty.naver.service.NaverAuthService;
+import com.depromeet.dodo.common.service.S3Service;
 
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -28,6 +31,8 @@ public class AuthorizeController {
 
 	private final NaverAuthService naverAuthService;
 	private final KakaoAuthService kakaoAuthService;
+
+	private final S3Service s3Service;
 
 	@GetMapping("/third-parties/naver/users")
 	@ApiOperation("네이버 유저의 정보를 가져오는 API")

--- a/src/main/java/com/depromeet/dodo/auth/controller/AuthorizeController.java
+++ b/src/main/java/com/depromeet/dodo/auth/controller/AuthorizeController.java
@@ -17,7 +17,6 @@ import com.depromeet.dodo.auth.thirdparty.kakao.service.KakaoAuthService;
 import com.depromeet.dodo.auth.thirdparty.naver.request.NaverSignInRequest;
 import com.depromeet.dodo.auth.thirdparty.naver.request.NaverSignUpRequest;
 import com.depromeet.dodo.auth.thirdparty.naver.service.NaverAuthService;
-import com.depromeet.dodo.common.service.S3Service;
 
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +30,6 @@ public class AuthorizeController {
 
 	private final NaverAuthService naverAuthService;
 	private final KakaoAuthService kakaoAuthService;
-
-	private final S3Service s3Service;
 
 	@GetMapping("/third-parties/naver/users")
 	@ApiOperation("네이버 유저의 정보를 가져오는 API")

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/AuthService.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/AuthService.java
@@ -1,13 +1,13 @@
 package com.depromeet.dodo.auth.thirdparty;
 
-import com.depromeet.dodo.auth.common.SignUpRequest;
-import com.depromeet.dodo.auth.common.UserInfo;
+import com.depromeet.dodo.auth.common.dto.SignUpRequest;
+import com.depromeet.dodo.auth.common.dto.UserInfo;
 
 public interface AuthService<SIGNUP extends SignUpRequest, SIGNIN extends ThirdPartyRequest> {
 
-    void signUp(SIGNUP request);
+	void signUp(SIGNUP request);
 
-    void signIn(SIGNIN request);
+	void signIn(SIGNIN request);
 
-    UserInfo getUserInfo(String userId, String token);
+	UserInfo getUserInfo(String userId, String token);
 }

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/request/KakaoSignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/request/KakaoSignUpRequest.java
@@ -2,7 +2,7 @@ package com.depromeet.dodo.auth.thirdparty.kakao.request;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import com.depromeet.dodo.auth.common.SignUpRequest;
+import com.depromeet.dodo.auth.common.dto.SignUpRequest;
 
 import lombok.Getter;
 

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/request/KakaoSignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/request/KakaoSignUpRequest.java
@@ -1,5 +1,7 @@
 package com.depromeet.dodo.auth.thirdparty.kakao.request;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.depromeet.dodo.auth.common.SignUpRequest;
 
 import lombok.Getter;
@@ -10,8 +12,8 @@ public class KakaoSignUpRequest extends SignUpRequest {
 	private String token;
 
 	public KakaoSignUpRequest(String username, int age, String address, String introduce, PetInfo petInfo,
-		String token) {
-		super(username, age, address, introduce, petInfo);
+		String token, MultipartFile profileImage) {
+		super(username, age, address, introduce, petInfo, profileImage);
 		this.token = token;
 	}
 }

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/service/KakaoAuthService.java
@@ -1,5 +1,7 @@
 package com.depromeet.dodo.auth.thirdparty.kakao.service;
 
+import java.util.List;
+
 import javax.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
@@ -12,6 +14,10 @@ import com.depromeet.dodo.auth.thirdparty.kakao.request.KakaoSignInRequest;
 import com.depromeet.dodo.auth.thirdparty.kakao.request.KakaoSignUpRequest;
 import com.depromeet.dodo.auth.thirdparty.kakao.response.KakaoProfileResponse;
 import com.depromeet.dodo.common.dto.Gender;
+import com.depromeet.dodo.common.service.FileUploadService;
+import com.depromeet.dodo.image.domain.Image;
+import com.depromeet.dodo.image.service.PetProfileService;
+import com.depromeet.dodo.image.service.UserProfileService;
 import com.depromeet.dodo.pet.domain.Pet;
 import com.depromeet.dodo.pet.service.PetService;
 import com.depromeet.dodo.user.domain.User;
@@ -30,6 +36,9 @@ public class KakaoAuthService implements AuthService<KakaoSignUpRequest, KakaoSi
 	private final KakaoAuthApiService kakaoAuthApiService;
 	private final UserService userService;
 	private final PetService petService;
+	private final PetProfileService petProfileService;
+	private final UserProfileService userProfileService;
+	private final FileUploadService fileUploadService;
 
 	private final UserRepository userRepository;
 
@@ -47,6 +56,8 @@ public class KakaoAuthService implements AuthService<KakaoSignUpRequest, KakaoSi
 			.vaccination(request.getPetInfo().isVaccination())
 			.build();
 
+		List<Image> petProfiles = fileUploadService.multiFileUpload(request.getPetInfo().getProfileImage());
+		petProfiles.stream().forEach(x -> petProfileService.addImage(pet, x));
 		petService.addPet(pet);
 
 		User newUser = User.builder()
@@ -60,6 +71,8 @@ public class KakaoAuthService implements AuthService<KakaoSignUpRequest, KakaoSi
 			.pet(pet)
 			.build();
 
+		Image userProfile = fileUploadService.singleFileUpload(request.getProfileImage());
+		userProfileService.addImage(newUser, userProfile);
 		userService.signUp(newUser);
 	}
 

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/service/KakaoAuthService.java
@@ -56,8 +56,10 @@ public class KakaoAuthService implements AuthService<KakaoSignUpRequest, KakaoSi
 			.vaccination(request.getPetInfo().isVaccination())
 			.build();
 
-		List<Image> petProfiles = fileUploadService.multiFileUpload(request.getPetInfo().getProfileImage());
-		petProfiles.stream().forEach(x -> petProfileService.addImage(pet, x));
+		if (!request.getPetInfo().getProfileImage().isEmpty()) {
+			List<Image> petProfiles = fileUploadService.multiFileUpload(request.getPetInfo().getProfileImage());
+			petProfiles.stream().forEach(x -> petProfileService.addImage(pet, x));
+		}
 		petService.addPet(pet);
 
 		User newUser = User.builder()
@@ -71,8 +73,10 @@ public class KakaoAuthService implements AuthService<KakaoSignUpRequest, KakaoSi
 			.pet(pet)
 			.build();
 
-		Image userProfile = fileUploadService.singleFileUpload(request.getProfileImage());
-		userProfileService.addImage(newUser, userProfile);
+		if (!request.getProfileImage().isEmpty()) {
+			Image userProfile = fileUploadService.singleFileUpload(request.getProfileImage());
+			userProfileService.addImage(newUser, userProfile);
+		}
 		userService.signUp(newUser);
 	}
 

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/request/NaverSignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/request/NaverSignUpRequest.java
@@ -1,5 +1,7 @@
 package com.depromeet.dodo.auth.thirdparty.naver.request;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.depromeet.dodo.auth.common.SignUpRequest;
 
 import lombok.Getter;
@@ -10,8 +12,8 @@ public class NaverSignUpRequest extends SignUpRequest {
 	private String token;
 
 	public NaverSignUpRequest(String username, int age, String address, String introduce, PetInfo petInfo,
-		String token) {
-		super(username, age, address, introduce, petInfo);
+		String token, MultipartFile profileImage) {
+		super(username, age, address, introduce, petInfo, profileImage);
 		this.token = token;
 	}
 }

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/request/NaverSignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/request/NaverSignUpRequest.java
@@ -2,7 +2,7 @@ package com.depromeet.dodo.auth.thirdparty.naver.request;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import com.depromeet.dodo.auth.common.SignUpRequest;
+import com.depromeet.dodo.auth.common.dto.SignUpRequest;
 
 import lombok.Getter;
 

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/service/NaverAuthService.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/service/NaverAuthService.java
@@ -57,8 +57,10 @@ public class NaverAuthService implements AuthService<NaverSignUpRequest, NaverSi
 			.vaccination(request.getPetInfo().isVaccination())
 			.build();
 
-		List<Image> petProfiles = fileUploadService.multiFileUpload(request.getPetInfo().getProfileImage());
-		petProfiles.stream().forEach(x -> petProfileService.addImage(pet, x));
+		if (!request.getPetInfo().getProfileImage().isEmpty()) {
+			List<Image> petProfiles = fileUploadService.multiFileUpload(request.getPetInfo().getProfileImage());
+			petProfiles.stream().forEach(x -> petProfileService.addImage(pet, x));
+		}
 		petService.addPet(pet);
 
 		User newUser = User.builder()
@@ -72,8 +74,10 @@ public class NaverAuthService implements AuthService<NaverSignUpRequest, NaverSi
 			.pet(pet)
 			.build();
 
-		Image userProfile = fileUploadService.singleFileUpload(request.getProfileImage());
-		userProfileService.addImage(newUser, userProfile);
+		if (!request.getProfileImage().isEmpty()) {
+			Image userProfile = fileUploadService.singleFileUpload(request.getProfileImage());
+			userProfileService.addImage(newUser, userProfile);
+		}
 		userService.signUp(newUser);
 	}
 

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/service/NaverAuthService.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/service/NaverAuthService.java
@@ -1,5 +1,7 @@
 package com.depromeet.dodo.auth.thirdparty.naver.service;
 
+import java.util.List;
+
 import javax.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
@@ -12,6 +14,10 @@ import com.depromeet.dodo.auth.thirdparty.naver.dto.NaverUserProfile;
 import com.depromeet.dodo.auth.thirdparty.naver.request.NaverSignInRequest;
 import com.depromeet.dodo.auth.thirdparty.naver.request.NaverSignUpRequest;
 import com.depromeet.dodo.common.dto.Gender;
+import com.depromeet.dodo.common.service.FileUploadService;
+import com.depromeet.dodo.image.domain.Image;
+import com.depromeet.dodo.image.service.PetProfileService;
+import com.depromeet.dodo.image.service.UserProfileService;
 import com.depromeet.dodo.pet.domain.Pet;
 import com.depromeet.dodo.pet.service.PetService;
 import com.depromeet.dodo.user.domain.User;
@@ -30,6 +36,9 @@ public class NaverAuthService implements AuthService<NaverSignUpRequest, NaverSi
 	private final NaverAuthApiService naverAuthApiService;
 	private final UserService userService;
 	private final PetService petService;
+	private final PetProfileService petProfileService;
+	private final UserProfileService userProfileService;
+	private final FileUploadService fileUploadService;
 
 	private final UserRepository userRepository;
 
@@ -48,6 +57,8 @@ public class NaverAuthService implements AuthService<NaverSignUpRequest, NaverSi
 			.vaccination(request.getPetInfo().isVaccination())
 			.build();
 
+		List<Image> petProfiles = fileUploadService.multiFileUpload(request.getPetInfo().getProfileImage());
+		petProfiles.stream().forEach(x -> petProfileService.addImage(pet, x));
 		petService.addPet(pet);
 
 		User newUser = User.builder()
@@ -61,6 +72,8 @@ public class NaverAuthService implements AuthService<NaverSignUpRequest, NaverSi
 			.pet(pet)
 			.build();
 
+		Image userProfile = fileUploadService.singleFileUpload(request.getProfileImage());
+		userProfileService.addImage(newUser, userProfile);
 		userService.signUp(newUser);
 	}
 

--- a/src/main/java/com/depromeet/dodo/common/dto/ImageWithPriority.java
+++ b/src/main/java/com/depromeet/dodo/common/dto/ImageWithPriority.java
@@ -1,0 +1,13 @@
+package com.depromeet.dodo.common.dto;
+
+import com.depromeet.dodo.image.domain.Image;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageWithPriority {
+	private Image image;
+	private int priority;
+}

--- a/src/main/java/com/depromeet/dodo/common/dto/ProfileImage.java
+++ b/src/main/java/com/depromeet/dodo/common/dto/ProfileImage.java
@@ -1,0 +1,14 @@
+package com.depromeet.dodo.common.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProfileImage {
+	private MultipartFile imageFile;
+	private int priority;
+}
+

--- a/src/main/java/com/depromeet/dodo/common/dto/S3UploadImage.java
+++ b/src/main/java/com/depromeet/dodo/common/dto/S3UploadImage.java
@@ -1,0 +1,21 @@
+package com.depromeet.dodo.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class S3UploadImage {
+	private ProfileImage profileImage;
+	private String fileName;
+	private String filePath;
+	private String folderName;
+
+	public S3UploadImage(ProfileImage profileImage, String folderName, String fileName) {
+		this.profileImage = profileImage;
+		this.folderName = folderName;
+		this.fileName = fileName;
+	}
+}

--- a/src/main/java/com/depromeet/dodo/common/exception/AwsS3SaveFailedException.java
+++ b/src/main/java/com/depromeet/dodo/common/exception/AwsS3SaveFailedException.java
@@ -1,0 +1,14 @@
+package com.depromeet.dodo.common.exception;
+
+import java.io.IOException;
+
+public class AwsS3SaveFailedException extends IOException {
+
+	public AwsS3SaveFailedException() {
+	}
+
+	public AwsS3SaveFailedException(String msg) {
+		super(msg);
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/common/exception/AwsS3SaveFailedException.java
+++ b/src/main/java/com/depromeet/dodo/common/exception/AwsS3SaveFailedException.java
@@ -7,8 +7,12 @@ public class AwsS3SaveFailedException extends IOException {
 	public AwsS3SaveFailedException() {
 	}
 
-	public AwsS3SaveFailedException(String msg) {
-		super(msg);
+	public AwsS3SaveFailedException(Throwable t) {
+		super(t);
+	}
+
+	public AwsS3SaveFailedException(String msg, Throwable t) {
+		super(msg, t);
 	}
 
 }

--- a/src/main/java/com/depromeet/dodo/common/service/FileUploadService.java
+++ b/src/main/java/com/depromeet/dodo/common/service/FileUploadService.java
@@ -1,0 +1,52 @@
+package com.depromeet.dodo.common.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.depromeet.dodo.image.domain.Image;
+import com.depromeet.dodo.image.service.ImageService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FileUploadService {
+	private static final Integer SINGLE_FILE_PRIORITY = 0;
+
+	private final S3Service s3Service;
+	private final ImageService imageService;
+
+	public Image singleFileUpload(MultipartFile file) {
+		Image image = null;
+		if (!file.isEmpty()) {
+			String fileName = UUID.randomUUID().toString();
+			image = new Image(s3Service.upload(file, fileName), fileName, SINGLE_FILE_PRIORITY);
+			imageService.addImage(image);
+		}
+
+		return image;
+	}
+
+	public List<Image> multiFileUpload(Map<Integer, MultipartFile> files) {
+		List<Image> images = null;
+		if (!images.isEmpty()) {
+			images = files.entrySet()
+				.stream()
+				.map(x -> {
+					String fileName = UUID.randomUUID().toString();
+					Image image = new Image(s3Service.upload(x.getValue(), fileName), fileName, x.getKey());
+					imageService.addImage(image);
+					return image;
+				})
+				.collect(Collectors.toList());
+		}
+
+		return images;
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/common/service/FileUploadService.java
+++ b/src/main/java/com/depromeet/dodo/common/service/FileUploadService.java
@@ -22,29 +22,23 @@ public class FileUploadService {
 	private final ImageService imageService;
 
 	public Image singleFileUpload(MultipartFile file) {
-		Image image = null;
-		if (!file.isEmpty()) {
-			String fileName = UUID.randomUUID().toString();
-			image = new Image(s3Service.upload(file, fileName), fileName, SINGLE_FILE_PRIORITY);
-			imageService.addImage(image);
-		}
+		String fileName = UUID.randomUUID().toString();
+		Image image = new Image(s3Service.upload(file, fileName), fileName, SINGLE_FILE_PRIORITY);
+		imageService.addImage(image);
 
 		return image;
 	}
 
 	public List<Image> multiFileUpload(Map<Integer, MultipartFile> files) {
-		List<Image> images = null;
-		if (!images.isEmpty()) {
-			images = files.entrySet()
-				.stream()
-				.map(x -> {
-					String fileName = UUID.randomUUID().toString();
-					Image image = new Image(s3Service.upload(x.getValue(), fileName), fileName, x.getKey());
-					imageService.addImage(image);
-					return image;
-				})
-				.collect(Collectors.toList());
-		}
+		List<Image> images = files.entrySet()
+			.stream()
+			.map(x -> {
+				String fileName = UUID.randomUUID().toString();
+				Image image = new Image(s3Service.upload(x.getValue(), fileName), fileName, x.getKey());
+				imageService.addImage(image);
+				return image;
+			})
+			.collect(Collectors.toList());
 
 		return images;
 	}

--- a/src/main/java/com/depromeet/dodo/common/service/S3Service.java
+++ b/src/main/java/com/depromeet/dodo/common/service/S3Service.java
@@ -1,6 +1,11 @@
 package com.depromeet.dodo.common.service;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
@@ -8,16 +13,24 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.transfer.MultipleFileUpload;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.depromeet.dodo.common.dto.S3UploadImage;
 import com.depromeet.dodo.common.exception.AwsS3SaveFailedException;
 import com.depromeet.dodo.config.AWSConfig;
 import com.depromeet.dodo.image.domain.Image;
 
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @PropertySource("classpath:aws.properties")
@@ -28,22 +41,86 @@ public class S3Service {
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
 
+	@Value("${aws.file.path}")
+	private String filePath;
+
 	@SneakyThrows
-	public String upload(MultipartFile file, String fileName) {
-		AmazonS3 s3Client = awsConfig.amazonS3Client(awsConfig.awsCredentialsProvider(awsConfig.basicAWSCredentials()));
+	public String uploadFile(MultipartFile file, String fileName) {
+		AmazonS3 s3Client = awsConfig.AwsS3Client();
+
+		ObjectMetadata metaData = new ObjectMetadata();
+		metaData.setContentLength(file.getBytes().length);
+
 		try {
-			s3Client.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), null)
+			s3Client.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), metaData)
 				.withCannedAcl(CannedAccessControlList.PublicRead));
-		} catch (IOException e) {
-			throw new AwsS3SaveFailedException("AWS S3 이미지 저장에 실패했습니다. : ".concat(e.toString()));
+		} catch (AmazonS3Exception | IOException e) {
+			throw new AwsS3SaveFailedException(e);
 		}
 
-		return s3Client.getUrl(bucket, fileName).toString();
+		return getUrl(bucket, fileName);
 	}
 
-	public void delete(Image image) {
-		AmazonS3 s3Client = awsConfig.amazonS3Client(awsConfig.awsCredentialsProvider(awsConfig.basicAWSCredentials()));
-		s3Client.deleteObject(new DeleteObjectRequest(bucket, image.getFileName()));
+	public String getUrl(String path, String fileName) {
+		AmazonS3 s3Client = awsConfig.AwsS3Client();
+		return s3Client.getUrl(path, fileName).toString();
+	}
+
+	public List<S3UploadImage> uploadFiles(String folderName, List<S3UploadImage> s3UploadImages) {
+		List<File> files = new ArrayList<>();
+		s3UploadImages.stream()
+			.forEach(x -> files.add(convert(x.getProfileImage().getImageFile(), x.getFileName())
+				.orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File로 전환이 실패했습니다."))));
+
+		List<String> filePaths = s3UploadFileList(folderName, files);
+		filePaths.stream().forEach(x -> s3UploadImages.get(filePaths.indexOf(x)).setFilePath(x));
+		return s3UploadImages;
+	}
+
+	@SneakyThrows
+	private List<String> s3UploadFileList(String folderName, List<File> files) {
+		AmazonS3 s3Client = awsConfig.AwsS3Client();
+		TransferManager xfer_mgr = TransferManagerBuilder.standard()
+			.withS3Client(s3Client)
+			.build();
+
+		MultipleFileUpload xfer = xfer_mgr.uploadFileList(bucket, folderName, new File(filePath), files);
+
+		try {
+			xfer.waitForCompletion();
+			xfer.waitForException();
+		} catch (InterruptedException e) {
+			throw new AwsS3SaveFailedException(e);
+		} finally {
+			files.stream().forEach(x -> x.delete());
+			xfer_mgr.shutdownNow();
+		}
+
+		List<String> filesUrl = new ArrayList<>();
+		files.stream().forEach(x -> filesUrl.add(getUrl(bucket.concat("/" + folderName), x.getName())));
+		return filesUrl;
+	}
+
+	@SneakyThrows
+	private Optional<File> convert(MultipartFile file, String fileName) {
+		File convertFile = new File(fileName);
+		try {
+			if (convertFile.createNewFile()) {
+				try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+					fos.write(file.getBytes());
+				}
+				return Optional.of(convertFile);
+			}
+		} catch (IOException e) {
+			throw new AwsS3SaveFailedException("MultipartFile -> File로 전환이 실패했습니다.", e);
+		}
+
+		return Optional.empty();
+	}
+
+	public void deleteS3Object(String path, Image image) {
+		AmazonS3 s3Client = awsConfig.AwsS3Client();
+		s3Client.deleteObject(new DeleteObjectRequest(path, image.getFileName()));
 	}
 
 }

--- a/src/main/java/com/depromeet/dodo/common/service/S3Service.java
+++ b/src/main/java/com/depromeet/dodo/common/service/S3Service.java
@@ -80,11 +80,11 @@ public class S3Service {
 	@SneakyThrows
 	private List<String> s3UploadFileList(String folderName, List<File> files) {
 		AmazonS3 s3Client = awsConfig.AwsS3Client();
-		TransferManager xfer_mgr = TransferManagerBuilder.standard()
+		TransferManager xferMgr = TransferManagerBuilder.standard()
 			.withS3Client(s3Client)
 			.build();
 
-		MultipleFileUpload xfer = xfer_mgr.uploadFileList(bucket, folderName, new File(filePath), files);
+		MultipleFileUpload xfer = xferMgr.uploadFileList(bucket, folderName, new File(filePath), files);
 
 		try {
 			xfer.waitForCompletion();
@@ -93,7 +93,7 @@ public class S3Service {
 			throw new AwsS3SaveFailedException(e);
 		} finally {
 			files.stream().forEach(x -> x.delete());
-			xfer_mgr.shutdownNow();
+			xferMgr.shutdownNow();
 		}
 
 		List<String> filesUrl = new ArrayList<>();

--- a/src/main/java/com/depromeet/dodo/common/service/S3Service.java
+++ b/src/main/java/com/depromeet/dodo/common/service/S3Service.java
@@ -1,0 +1,49 @@
+package com.depromeet.dodo.common.service;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.depromeet.dodo.common.exception.AwsS3SaveFailedException;
+import com.depromeet.dodo.config.AWSConfig;
+import com.depromeet.dodo.image.domain.Image;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+@Service
+@RequiredArgsConstructor
+@PropertySource("classpath:aws.properties")
+public class S3Service {
+
+	private final AWSConfig awsConfig;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	@SneakyThrows
+	public String upload(MultipartFile file, String fileName) {
+		AmazonS3 s3Client = awsConfig.amazonS3Client(awsConfig.awsCredentialsProvider(awsConfig.basicAWSCredentials()));
+		try {
+			s3Client.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), null)
+				.withCannedAcl(CannedAccessControlList.PublicRead));
+		} catch (IOException e) {
+			throw new AwsS3SaveFailedException("AWS S3 이미지 저장에 실패했습니다. : ".concat(e.toString()));
+		}
+
+		return s3Client.getUrl(bucket, fileName).toString();
+	}
+
+	public void delete(Image image) {
+		AmazonS3 s3Client = awsConfig.amazonS3Client(awsConfig.awsCredentialsProvider(awsConfig.basicAWSCredentials()));
+		s3Client.deleteObject(new DeleteObjectRequest(bucket, image.getFileName()));
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/config/AWSConfig.java
+++ b/src/main/java/com/depromeet/dodo/config/AWSConfig.java
@@ -5,9 +5,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
@@ -21,35 +21,16 @@ public class AWSConfig {
 	@Value("${cloud.aws.credentials.secretKey}")
 	private String secretKey;
 
-	@Value("${cloud.aws.region.static}")
-	private String region;
-
 	@Bean
-	public BasicAWSCredentials basicAWSCredentials() {
+	public BasicAWSCredentials AwsCredentials() {
 		return new BasicAWSCredentials(accessKey, secretKey);
 	}
 
 	@Bean
-	public AWSCredentialsProvider awsCredentialsProvider(AWSCredentials awsCredentials) {
-		return new AWSCredentialsProvider() {
-			@Override
-			public AWSCredentials getCredentials() {
-				return awsCredentials;
-			}
-
-			@Override
-			public void refresh() {
-			}
-
-		};
-	}
-
-	@Bean
-	public AmazonS3 amazonS3Client(AWSCredentialsProvider awsCredentialsProvider) {
-		return AmazonS3ClientBuilder
-			.standard()
-			.withCredentials(awsCredentialsProvider)
-			.withRegion(this.region)
+	public AmazonS3 AwsS3Client() {
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(Regions.AP_NORTHEAST_2)
+			.withCredentials(new AWSStaticCredentialsProvider(this.AwsCredentials()))
 			.build();
 	}
 

--- a/src/main/java/com/depromeet/dodo/config/AWSConfig.java
+++ b/src/main/java/com/depromeet/dodo/config/AWSConfig.java
@@ -1,0 +1,56 @@
+package com.depromeet.dodo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+@PropertySource("classpath:aws.properties")
+public class AWSConfig {
+
+	@Value("${cloud.aws.credentials.accessKey}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secretKey}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public BasicAWSCredentials basicAWSCredentials() {
+		return new BasicAWSCredentials(accessKey, secretKey);
+	}
+
+	@Bean
+	public AWSCredentialsProvider awsCredentialsProvider(AWSCredentials awsCredentials) {
+		return new AWSCredentialsProvider() {
+			@Override
+			public AWSCredentials getCredentials() {
+				return awsCredentials;
+			}
+
+			@Override
+			public void refresh() {
+			}
+
+		};
+	}
+
+	@Bean
+	public AmazonS3 amazonS3Client(AWSCredentialsProvider awsCredentialsProvider) {
+		return AmazonS3ClientBuilder
+			.standard()
+			.withCredentials(awsCredentialsProvider)
+			.withRegion(this.region)
+			.build();
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/image/domain/Image.java
+++ b/src/main/java/com/depromeet/dodo/image/domain/Image.java
@@ -1,44 +1,37 @@
-package com.depromeet.dodo.pet.domain;
+package com.depromeet.dodo.image.domain;
 
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import com.depromeet.dodo.common.dto.Gender;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "Pet")
+@Table(name = "Image")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
-public class Pet {
+public class Image {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private long id;
+	private Long id;
 
-	private String name;
+	private String filePath;
 
-	@Enumerated(EnumType.STRING)
-	private Gender gender;
+	private String fileName;
 
-	private int age;
+	private int priority;
 
-	private String breed;
-
-	private boolean fixing;
-
-	private boolean vaccination;
+	public Image(String filePath, String fileName, int priority) {
+		this.filePath = filePath;
+		this.fileName = fileName;
+		this.priority = priority;
+	}
 
 }

--- a/src/main/java/com/depromeet/dodo/image/domain/Image.java
+++ b/src/main/java/com/depromeet/dodo/image/domain/Image.java
@@ -26,12 +26,9 @@ public class Image {
 
 	private String fileName;
 
-	private int priority;
-
-	public Image(String filePath, String fileName, int priority) {
+	public Image(String filePath, String fileName) {
 		this.filePath = filePath;
 		this.fileName = fileName;
-		this.priority = priority;
 	}
 
 }

--- a/src/main/java/com/depromeet/dodo/image/domain/PetProfile.java
+++ b/src/main/java/com/depromeet/dodo/image/domain/PetProfile.java
@@ -11,6 +11,7 @@ import javax.persistence.Table;
 import com.depromeet.dodo.pet.domain.Pet;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "PetProfile")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class PetProfile {
 
 	@Id
@@ -32,9 +34,12 @@ public class PetProfile {
 	@JoinColumn(name = "petId")
 	private Pet pet;
 
-	public PetProfile(Image image, Pet pet) {
+	private int priority;
+
+	public PetProfile(Image image, Pet pet, int priority) {
 		this.image = image;
 		this.pet = pet;
+		this.priority = priority;
 	}
 
 }

--- a/src/main/java/com/depromeet/dodo/image/domain/PetProfile.java
+++ b/src/main/java/com/depromeet/dodo/image/domain/PetProfile.java
@@ -1,8 +1,6 @@
-package com.depromeet.dodo.user.domain;
+package com.depromeet.dodo.image.domain;
 
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -10,44 +8,33 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
-import com.depromeet.dodo.common.dto.Gender;
 import com.depromeet.dodo.pet.domain.Pet;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "User")
+@Table(name = "PetProfile")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
-public class User {
+public class PetProfile {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private long id;
+	private Long id;
 
-	private String uid;
-
-	private String username;
-
-	@Enumerated(EnumType.STRING)
-	private Gender gender;
-
-	private int age;
-
-	private String address;
-
-	private String introduce;
-
-	private String profileImageUrl;
+	@OneToOne
+	@JoinColumn(name = "imageId")
+	private Image image;
 
 	@OneToOne
 	@JoinColumn(name = "petId")
 	private Pet pet;
+
+	public PetProfile(Image image, Pet pet) {
+		this.image = image;
+		this.pet = pet;
+	}
 
 }

--- a/src/main/java/com/depromeet/dodo/image/domain/UserProfile.java
+++ b/src/main/java/com/depromeet/dodo/image/domain/UserProfile.java
@@ -1,0 +1,41 @@
+package com.depromeet.dodo.image.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import com.depromeet.dodo.user.domain.User;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "UserProfile")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserProfile {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "imageId")
+	private Image image;
+
+	@OneToOne
+	@JoinColumn(name = "userId")
+	private User user;
+
+	public UserProfile(Image image, User user) {
+		this.image = image;
+		this.user = user;
+	}
+}

--- a/src/main/java/com/depromeet/dodo/image/repository/ImageRepository.java
+++ b/src/main/java/com/depromeet/dodo/image/repository/ImageRepository.java
@@ -1,0 +1,11 @@
+package com.depromeet.dodo.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.depromeet.dodo.image.domain.Image;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+}

--- a/src/main/java/com/depromeet/dodo/image/repository/ImageRepository.java
+++ b/src/main/java/com/depromeet/dodo/image/repository/ImageRepository.java
@@ -7,5 +7,4 @@ import com.depromeet.dodo.image.domain.Image;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
-
 }

--- a/src/main/java/com/depromeet/dodo/image/repository/PetProfileRepository.java
+++ b/src/main/java/com/depromeet/dodo/image/repository/PetProfileRepository.java
@@ -1,0 +1,10 @@
+package com.depromeet.dodo.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.depromeet.dodo.image.domain.PetProfile;
+
+@Repository
+public interface PetProfileRepository extends JpaRepository<PetProfile, Long> {
+}

--- a/src/main/java/com/depromeet/dodo/image/repository/UserProfileRepository.java
+++ b/src/main/java/com/depromeet/dodo/image/repository/UserProfileRepository.java
@@ -1,0 +1,10 @@
+package com.depromeet.dodo.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.depromeet.dodo.image.domain.UserProfile;
+
+@Repository
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+}

--- a/src/main/java/com/depromeet/dodo/image/service/ImageService.java
+++ b/src/main/java/com/depromeet/dodo/image/service/ImageService.java
@@ -1,0 +1,23 @@
+package com.depromeet.dodo.image.service;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import com.depromeet.dodo.image.domain.Image;
+import com.depromeet.dodo.image.repository.ImageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+	private final ImageRepository imageRepository;
+
+	@Transactional
+	public void addImage(Image image) {
+		imageRepository.save(image);
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/image/service/ImageService.java
+++ b/src/main/java/com/depromeet/dodo/image/service/ImageService.java
@@ -1,5 +1,7 @@
 package com.depromeet.dodo.image.service;
 
+import java.util.List;
+
 import javax.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
@@ -18,6 +20,11 @@ public class ImageService {
 	@Transactional
 	public void addImage(Image image) {
 		imageRepository.save(image);
+	}
+
+	@Transactional
+	public void addImages(List<Image> images) {
+		imageRepository.saveAll(images);
 	}
 
 }

--- a/src/main/java/com/depromeet/dodo/image/service/PetProfileService.java
+++ b/src/main/java/com/depromeet/dodo/image/service/PetProfileService.java
@@ -1,0 +1,25 @@
+package com.depromeet.dodo.image.service;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import com.depromeet.dodo.image.domain.Image;
+import com.depromeet.dodo.image.domain.PetProfile;
+import com.depromeet.dodo.image.repository.PetProfileRepository;
+import com.depromeet.dodo.pet.domain.Pet;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PetProfileService {
+
+	private final PetProfileRepository petProfileRepository;
+
+	@Transactional
+	public void addImage(Pet pet, Image image) {
+		petProfileRepository.save(new PetProfile(image, pet));
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/image/service/PetProfileService.java
+++ b/src/main/java/com/depromeet/dodo/image/service/PetProfileService.java
@@ -1,13 +1,13 @@
 package com.depromeet.dodo.image.service;
 
+import java.util.List;
+
 import javax.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
 
-import com.depromeet.dodo.image.domain.Image;
 import com.depromeet.dodo.image.domain.PetProfile;
 import com.depromeet.dodo.image.repository.PetProfileRepository;
-import com.depromeet.dodo.pet.domain.Pet;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,8 +18,8 @@ public class PetProfileService {
 	private final PetProfileRepository petProfileRepository;
 
 	@Transactional
-	public void addImage(Pet pet, Image image) {
-		petProfileRepository.save(new PetProfile(image, pet));
+	public void addProfiles(List<PetProfile> petProfiles) {
+		petProfileRepository.saveAll(petProfiles);
 	}
 
 }

--- a/src/main/java/com/depromeet/dodo/image/service/UserProfileService.java
+++ b/src/main/java/com/depromeet/dodo/image/service/UserProfileService.java
@@ -1,0 +1,25 @@
+package com.depromeet.dodo.image.service;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import com.depromeet.dodo.image.domain.Image;
+import com.depromeet.dodo.image.domain.UserProfile;
+import com.depromeet.dodo.image.repository.UserProfileRepository;
+import com.depromeet.dodo.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserProfileService {
+
+	private final UserProfileRepository userProfileRepository;
+
+	@Transactional
+	public void addImage(User user, Image image) {
+		userProfileRepository.save(new UserProfile(image, user));
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/user/service/UserService.java
+++ b/src/main/java/com/depromeet/dodo/user/service/UserService.java
@@ -17,9 +17,7 @@ public class UserService {
 
 	@Transactional
 	public void signUp(User user) {
-
 		// TODO : 추가 로직
-
 		userRepository.save(user);
 	}
 }

--- a/src/main/resources/application-default.yml
+++ b/src/main/resources/application-default.yml
@@ -1,6 +1,5 @@
-
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/dodo?useUnicode=true&characterEncoding=utf8
+    url: jdbc:mysql://localhost:3306/dodo?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8
     username:
     password:

--- a/src/test/java/com/depromeet/dodo/ApplicationTests.java
+++ b/src/test/java/com/depromeet/dodo/ApplicationTests.java
@@ -1,9 +1,7 @@
 package com.depromeet.dodo;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class ApplicationTests {
 
 	@Test

--- a/src/test/java/com/depromeet/dodo/ApplicationTests.java
+++ b/src/test/java/com/depromeet/dodo/ApplicationTests.java
@@ -1,7 +1,9 @@
 package com.depromeet.dodo;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
 
+@SpringBootTest
 class ApplicationTests {
 
 	@Test


### PR DESCRIPTION
- Image 용도에 맞게 중간 테이블 생성 (ex. PetProfile, UserProfile)    

- aws s3 연동   

- signup 기능에 이미지 저장 기능 추가   

- aws.properties는 젠킨스 스크립트에서 확인 가능합니다.      