### PR TITLE
[#39] 사용자 주소 조회 및 저장 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,16 @@
             <version>2.2.1.RELEASE</version>
         </dependency>
         <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+            <version>1.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-spatial</artifactId>
+            <version>5.2.5.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -12,6 +12,7 @@ create table User
 	introduce varchar(200) null,
 	profileImageUrl varchar(500) null,
 	petId bigint not null,
+	locationId bigint,
 	constraint uid
 		unique (uid)
 );
@@ -49,4 +50,12 @@ CREATE TABLE UserProfile
     id bigint auto_increment primary key,
     imageId bigint not null,
     userId bigint not null
+);
+
+CREATE TABLE Location
+(
+    id bigint auto_increment primary key,
+    point point not null,
+    addressName varchar(100) not null,
+    region3DepthName varchar(100) not null
 );

--- a/src/main/java/com/depromeet/dodo/auth/common/dto/KakaoAddressResponse.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/dto/KakaoAddressResponse.java
@@ -1,0 +1,31 @@
+package com.depromeet.dodo.auth.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoAddressResponse {
+
+	private Address address;
+
+	@JsonCreator
+	public KakaoAddressResponse(@JsonProperty("address") Address address) {
+		this.address = address;
+	}
+
+	@Getter
+	public class Address {
+		private String addressName;
+		private String region3DepthName;
+
+		@JsonCreator
+		public Address(@JsonProperty("address_name") String addressName,
+			@JsonProperty("region_3depth_name") String region3DepthName) {
+			this.addressName = addressName;
+			this.region3DepthName = region3DepthName;
+		}
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/auth/common/dto/KakaoErrorResponse.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/dto/KakaoErrorResponse.java
@@ -1,0 +1,11 @@
+package com.depromeet.dodo.auth.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class KakaoErrorResponse {
+	private int code;
+	private String msg;
+}

--- a/src/main/java/com/depromeet/dodo/auth/common/dto/SignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/dto/SignUpRequest.java
@@ -6,6 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.depromeet.dodo.common.dto.Gender;
 import com.depromeet.dodo.common.dto.ProfileImage;
+import com.vividsolutions.jts.geom.Point;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,7 +17,7 @@ public class SignUpRequest {
 
 	private String username;
 	private int age;
-	private String address;
+	private Point address;
 	private String introduce;
 	private PetInfo petInfo;
 	private MultipartFile profileImage;

--- a/src/main/java/com/depromeet/dodo/auth/common/service/AddressService.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/service/AddressService.java
@@ -1,0 +1,31 @@
+package com.depromeet.dodo.auth.common.service;
+
+import org.springframework.stereotype.Service;
+
+import com.depromeet.dodo.location.domain.Location;
+import com.depromeet.dodo.location.service.LocationService;
+import com.vividsolutions.jts.geom.Point;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AddressService {
+
+	private final LocationService locationService;
+
+	public Location addLocation(Point point, KakaoMapApiService.KakaoMapResponse response) {
+		Location location = null;
+
+		if(!response.getKakaoAddressResponse().isEmpty()) {
+			location = Location.builder()
+				.point(point)
+				.addressName(response.getKakaoAddressResponse().get(0).getAddress().getRegion3DepthName())
+				.region3DepthName(response.getKakaoAddressResponse().get(0).getAddress().getRegion3DepthName()).build();
+			locationService.addLocation(location);
+		}
+
+		return location;
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/auth/common/service/KakaoMapApiService.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/service/KakaoMapApiService.java
@@ -1,0 +1,56 @@
+package com.depromeet.dodo.auth.common.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.depromeet.dodo.auth.common.dto.KakaoAddressResponse;
+import com.depromeet.dodo.auth.common.dto.KakaoErrorResponse;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vividsolutions.jts.geom.Point;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoMapApiService {
+
+	@Value("${kakao.api.map.secret.key}")
+	private final String KAKAO_MAP_AUTH_VALUE;
+	private static final String KAKAO_MAP_AUTH_KEY = "Authorization";
+	private static final String KAKAO_MAP_URL = "https://dapi.kakao.com/v2/local/geo/coord2address.json";
+
+	private final WebClient apiWebClient;
+
+	public KakaoMapResponse getAddress(Point point) {
+		return apiWebClient.get()
+			.uri(addQuerystring(KAKAO_MAP_URL, point))
+			.header(KAKAO_MAP_AUTH_KEY, KAKAO_MAP_AUTH_VALUE)
+			.retrieve()
+			.onStatus(status -> status.is4xxClientError(),
+				response -> response.bodyToMono(KakaoErrorResponse.class)
+					.map(body -> new IllegalArgumentException(body.getMsg())))
+			.bodyToMono(KakaoMapResponse.class)
+			.block();
+	}
+
+	private String addQuerystring(String url, Point point) {
+		return url + "?x=" + point.getX() + "&y=" + point.getY() + "&input_coord=WTM";
+	}
+
+	@Getter
+	public static class KakaoMapResponse {
+		private List<KakaoAddressResponse> kakaoAddressResponse;
+
+		@JsonCreator
+		public KakaoMapResponse(@JsonProperty("documents") List<KakaoAddressResponse> kakaoAddressResponse) {
+			this.kakaoAddressResponse = kakaoAddressResponse;
+		}
+
+	}
+
+}

--- a/src/main/java/com/depromeet/dodo/auth/common/service/KakaoMapApiService.java
+++ b/src/main/java/com/depromeet/dodo/auth/common/service/KakaoMapApiService.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class KakaoMapApiService {
 
 	@Value("${kakao.api.map.secret.key}")
-	private final String KAKAO_MAP_AUTH_VALUE;
+	private final String kakaoMapAuthValue;
 	private static final String KAKAO_MAP_AUTH_KEY = "Authorization";
 	private static final String KAKAO_MAP_URL = "https://dapi.kakao.com/v2/local/geo/coord2address.json";
 
@@ -29,7 +29,7 @@ public class KakaoMapApiService {
 	public KakaoMapResponse getAddress(Point point) {
 		return apiWebClient.get()
 			.uri(addQuerystring(KAKAO_MAP_URL, point))
-			.header(KAKAO_MAP_AUTH_KEY, KAKAO_MAP_AUTH_VALUE)
+			.header(KAKAO_MAP_AUTH_KEY, kakaoMapAuthValue)
 			.retrieve()
 			.onStatus(status -> status.is4xxClientError(),
 				response -> response.bodyToMono(KakaoErrorResponse.class)

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/api/KakaoAuthApiService.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/api/KakaoAuthApiService.java
@@ -3,9 +3,9 @@ package com.depromeet.dodo.auth.thirdparty.kakao.api;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.depromeet.dodo.auth.common.dto.KakaoErrorResponse;
 import com.depromeet.dodo.auth.thirdparty.kakao.response.KakaoProfileResponse;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -27,12 +27,6 @@ public class KakaoAuthApiService {
 					.map(body -> new IllegalArgumentException(body.getMsg())))
 			.bodyToMono(KakaoProfileResponse.class)
 			.block();
-	}
-
-	@Getter
-	public static class KakaoErrorResponse {
-		private int code;
-		private String msg;
 	}
 
 }

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/request/KakaoSignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/request/KakaoSignUpRequest.java
@@ -3,6 +3,7 @@ package com.depromeet.dodo.auth.thirdparty.kakao.request;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.depromeet.dodo.auth.common.dto.SignUpRequest;
+import com.vividsolutions.jts.geom.Point;
 
 import lombok.Getter;
 
@@ -11,7 +12,7 @@ public class KakaoSignUpRequest extends SignUpRequest {
 
 	private String token;
 
-	public KakaoSignUpRequest(String username, int age, String address, String introduce, PetInfo petInfo,
+	public KakaoSignUpRequest(String username, int age, Point address, String introduce, PetInfo petInfo,
 		String token, MultipartFile profileImage) {
 		super(username, age, address, introduce, petInfo, profileImage);
 		this.token = token;

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/kakao/service/KakaoAuthService.java
@@ -5,6 +5,8 @@ import javax.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import com.depromeet.dodo.auth.common.dto.UserInfo;
+import com.depromeet.dodo.auth.common.service.KakaoMapApiService;
+import com.depromeet.dodo.auth.common.service.AddressService;
 import com.depromeet.dodo.auth.common.service.ProfileUploadService;
 import com.depromeet.dodo.auth.login.LoginService;
 import com.depromeet.dodo.auth.thirdparty.AuthService;
@@ -13,6 +15,7 @@ import com.depromeet.dodo.auth.thirdparty.kakao.request.KakaoSignInRequest;
 import com.depromeet.dodo.auth.thirdparty.kakao.request.KakaoSignUpRequest;
 import com.depromeet.dodo.auth.thirdparty.kakao.response.KakaoProfileResponse;
 import com.depromeet.dodo.common.dto.Gender;
+import com.depromeet.dodo.location.domain.Location;
 import com.depromeet.dodo.pet.domain.Pet;
 import com.depromeet.dodo.pet.service.PetService;
 import com.depromeet.dodo.user.domain.User;
@@ -29,8 +32,10 @@ public class KakaoAuthService implements AuthService<KakaoSignUpRequest, KakaoSi
 
 	private final LoginService loginService;
 	private final KakaoAuthApiService kakaoAuthApiService;
+	private final KakaoMapApiService kakaoMapApiService;
 	private final UserService userService;
 	private final PetService petService;
+	private final AddressService addressService;
 	private final ProfileUploadService profileUploadService;
 
 	private final UserRepository userRepository;
@@ -55,13 +60,16 @@ public class KakaoAuthService implements AuthService<KakaoSignUpRequest, KakaoSi
 			profileUploadService.addPetProfile(pet, request.getPetInfo().getProfileImages());
 		}
 
+		KakaoMapApiService.KakaoMapResponse response = kakaoMapApiService.getAddress(request.getAddress());
+		Location location = addressService.addLocation(request.getAddress(), response);
+
 		User newUser = User.builder()
 			.uid(generateUserUid(kakaoUserProfile.getId()))
 			.gender(Gender.of(kakaoUserProfile.getKakaoAccount().getGender()))
 			.profileImageUrl(kakaoUserProfile.getKakaoAccount().getProfile().getProfileImageUrl())
 			.introduce(request.getIntroduce())
 			.username(request.getUsername())
-			.address(request.getAddress())
+			.location(location)
 			.age(request.getAge())
 			.pet(pet)
 			.build();

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/request/NaverSignUpRequest.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/request/NaverSignUpRequest.java
@@ -3,6 +3,7 @@ package com.depromeet.dodo.auth.thirdparty.naver.request;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.depromeet.dodo.auth.common.dto.SignUpRequest;
+import com.vividsolutions.jts.geom.Point;
 
 import lombok.Getter;
 
@@ -11,7 +12,7 @@ public class NaverSignUpRequest extends SignUpRequest {
 
 	private String token;
 
-	public NaverSignUpRequest(String username, int age, String address, String introduce, PetInfo petInfo,
+	public NaverSignUpRequest(String username, int age, Point address, String introduce, PetInfo petInfo,
 		String token, MultipartFile profileImage) {
 		super(username, age, address, introduce, petInfo, profileImage);
 		this.token = token;

--- a/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/service/NaverAuthService.java
+++ b/src/main/java/com/depromeet/dodo/auth/thirdparty/naver/service/NaverAuthService.java
@@ -5,6 +5,8 @@ import javax.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import com.depromeet.dodo.auth.common.dto.UserInfo;
+import com.depromeet.dodo.auth.common.service.KakaoMapApiService;
+import com.depromeet.dodo.auth.common.service.AddressService;
 import com.depromeet.dodo.auth.common.service.ProfileUploadService;
 import com.depromeet.dodo.auth.login.LoginService;
 import com.depromeet.dodo.auth.thirdparty.AuthService;
@@ -13,6 +15,7 @@ import com.depromeet.dodo.auth.thirdparty.naver.dto.NaverUserProfile;
 import com.depromeet.dodo.auth.thirdparty.naver.request.NaverSignInRequest;
 import com.depromeet.dodo.auth.thirdparty.naver.request.NaverSignUpRequest;
 import com.depromeet.dodo.common.dto.Gender;
+import com.depromeet.dodo.location.domain.Location;
 import com.depromeet.dodo.pet.domain.Pet;
 import com.depromeet.dodo.pet.service.PetService;
 import com.depromeet.dodo.user.domain.User;
@@ -29,8 +32,10 @@ public class NaverAuthService implements AuthService<NaverSignUpRequest, NaverSi
 
 	private final LoginService loginService;
 	private final NaverAuthApiService naverAuthApiService;
+	private final KakaoMapApiService kakaoMapApiService;
 	private final UserService userService;
 	private final PetService petService;
+	private final AddressService addressService;
 	private final ProfileUploadService profileUploadService;
 
 	private final UserRepository userRepository;
@@ -55,13 +60,16 @@ public class NaverAuthService implements AuthService<NaverSignUpRequest, NaverSi
 		}
 		petService.addPet(pet);
 
+		KakaoMapApiService.KakaoMapResponse response = kakaoMapApiService.getAddress(request.getAddress());
+		Location location = addressService.addLocation(request.getAddress(), response);
+
 		User newUser = User.builder()
 			.uid(generateUserUid(naverProfile.getId()))
 			.gender(Gender.of(naverProfile.getGender()))
 			.profileImageUrl(naverProfile.getProfileImage())
 			.introduce(request.getIntroduce())
 			.username(request.getUsername())
-			.address(request.getAddress())
+			.location(location)
 			.age(request.getAge())
 			.pet(pet)
 			.build();

--- a/src/main/java/com/depromeet/dodo/location/domain/Location.java
+++ b/src/main/java/com/depromeet/dodo/location/domain/Location.java
@@ -1,0 +1,35 @@
+package com.depromeet.dodo.location.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import com.vividsolutions.jts.geom.Point;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@Table(name = "Location")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Location {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id;
+
+	private Point point;
+
+	private String addressName;
+
+	private String region3DepthName;
+
+}

--- a/src/main/java/com/depromeet/dodo/location/repository/LocationRepository.java
+++ b/src/main/java/com/depromeet/dodo/location/repository/LocationRepository.java
@@ -1,0 +1,11 @@
+package com.depromeet.dodo.location.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.depromeet.dodo.location.domain.Location;
+
+@Repository
+public interface LocationRepository extends JpaRepository<Location, Long> {
+}
+

--- a/src/main/java/com/depromeet/dodo/location/service/LocationService.java
+++ b/src/main/java/com/depromeet/dodo/location/service/LocationService.java
@@ -1,0 +1,22 @@
+package com.depromeet.dodo.location.service;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import com.depromeet.dodo.location.domain.Location;
+import com.depromeet.dodo.location.repository.LocationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+	private final LocationRepository locationRepository;
+
+	@Transactional
+	public void addLocation(Location location) {
+		locationRepository.save(location);
+	}
+}

--- a/src/main/java/com/depromeet/dodo/user/domain/User.java
+++ b/src/main/java/com/depromeet/dodo/user/domain/User.java
@@ -11,6 +11,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import com.depromeet.dodo.common.dto.Gender;
+import com.depromeet.dodo.location.domain.Location;
 import com.depromeet.dodo.pet.domain.Pet;
 
 import lombok.AccessLevel;
@@ -40,11 +41,13 @@ public class User {
 
 	private int age;
 
-	private String address;
-
 	private String introduce;
 
 	private String profileImageUrl;
+
+	@OneToOne
+	@JoinColumn(name = "locationId")
+	private Location location;
 
 	@OneToOne
 	@JoinColumn(name = "petId")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   jpa:
     hibernate:
@@ -10,3 +9,5 @@ spring:
     properties:
       show_sql: true
       format_sql: true
+      hibernate:
+        dialect: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,9 +5,8 @@ spring:
       naming:
         implicit-strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    # spatial 데이터 유형 (Point 사용을 위해) 지원 설정
+    database-platform: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect
     properties:
       show_sql: true
       format_sql: true
-      hibernate:
-        dialect: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect


### PR DESCRIPTION
### [#39] 사용자 주소 조회 및 저장   

- 클라이언트에서 `Point(x, y)` 를 받아 kakao map api를 이용하여 주소를 조회합니다.   

- 전체 주소 / 읍, 면, 동 / 거리 계산을 위해 `Point` 를 저장합니다.      

- `KAKAO_MAP_AUTH_VALUE` 는 젠킨스 스크립트에서 확인 가능합니다.  (kakao dev에서 받은 api key)        

   

 resolve #39
